### PR TITLE
Fix/auth redirect uri

### DIFF
--- a/bitloops-rest/src/services/Auth/auth.service.ts
+++ b/bitloops-rest/src/services/Auth/auth.service.ts
@@ -52,8 +52,7 @@ export default class AuthService implements IAuthenticationService {
 		oAuthProvider: OAuthProvider,
 		{ provider_id, client_id, session_uuid, workspace_id, redirect_uri },
 	) {
-		const redirectUri =
-			redirect_uri ?? `${this.REST_URI}/${provider_id}/auth/${this.mapper[oAuthProvider]}/final-callback`;
+		const redirectUri = redirect_uri ?? `${this.REST_URI}/bitloops/auth/${this.mapper[oAuthProvider]}/final-callback`;
 		const url = this.getAuthSessionBaseURL(provider_id);
 		const authSessionURL = buildUrlWithParams(url, {
 			client_id,

--- a/bitloops-rest/src/services/mongo/Mongo.ts
+++ b/bitloops-rest/src/services/mongo/Mongo.ts
@@ -98,7 +98,7 @@ class Mongo implements IDatabase {
 			},
 		);
 		console.log('client secret found', findResult);
-		const secret = findResult.clients?.[0].secret;
+		const secret = findResult?.clients?.[0].secret;
 		return secret ?? null;
 	}
 }


### PR DESCRIPTION
auth redirect url should not contain providerId, bitloops is a const part of our bitloops-rest routes, not the providerId