### PR TITLE
Add jwt claims in Bitloops User

### DIFF
--- a/bitloops-rest/src/services/Auth/auth.service.ts
+++ b/bitloops-rest/src/services/Auth/auth.service.ts
@@ -16,7 +16,7 @@ import { getPublicKey } from '../../routes/helpers';
 import { JWTStatuses } from '../../routes/definitions';
 import { Options } from '..';
 import { KeycloakSettings } from '../../constants';
-import { OAuthProvider } from './definitions';
+import { BitloopsUser, OAuthProvider } from './definitions';
 
 const replaceCookie = (cookies: Cookie[], newCookie: Cookie): Cookie[] => {
 	const newCookies = cookies.filter((cookie) => cookie.name !== newCookie.name);
@@ -146,7 +146,7 @@ export default class AuthService implements IAuthenticationService {
 		}
 		const jwtData = jwt?.jwtData;
 		// console.log('jwtData', jwtData);
-		const payload = {
+		const payload: BitloopsUser = {
 			displayName: jwtData.name,
 			email: jwtData.email,
 			emailVerified: jwtData.email_verified,
@@ -160,6 +160,7 @@ export default class AuthService implements IAuthenticationService {
 			clientId: sessionInfo.clientId,
 			sessionState: response.data.session_state,
 			isAnonymous: false,
+			jwt: jwtData,
 		};
 		const authStateChangeTopic = `workflow-events.${sessionInfo.workspaceId}.auth:${sessionInfo.providerId}:${sessionInfo.sessionUuid}`;
 		console.log(`publishing to ${authStateChangeTopic}`);

--- a/bitloops-rest/src/services/Auth/definitions.ts
+++ b/bitloops-rest/src/services/Auth/definitions.ts
@@ -1,1 +1,19 @@
+import { JWTData } from '../../controllers/definitions';
+
 export type OAuthProvider = 'google' | 'github';
+export type BitloopsUser = {
+	accessToken: string;
+	refreshToken: string;
+	sessionState: string;
+	uid: string;
+	displayName: string;
+	firstName: string;
+	lastName: string;
+	email: string;
+	emailVerified: boolean;
+	isAnonymous: boolean;
+	providerId: string;
+	clientId: string;
+	photoURL: string;
+	jwt?: JWTData;
+};


### PR DESCRIPTION
Insert token claims inside Bitloops User, so that client applications can use group_names & other custom user attributes they may attach to their users.